### PR TITLE
Don't leak mapping if madvise fails.

### DIFF
--- a/fs/os.go
+++ b/fs/os.go
@@ -94,9 +94,7 @@ func (f *osfile) Mmap(size int64) error {
 	if err != nil {
 		return err
 	}
-	if err := madviceRandom(data); err != nil {
-		return nil
-	}
+	madviceRandom(data)
 	f.data = data
 	return nil
 }


### PR DESCRIPTION
The runtime keeps references to mmap'd regions, so they aren't automatically closed. Besides, madvise is a hint, so this shouldn't fail if that returns an error.