### PR TITLE
Make db.sync public

### DIFF
--- a/db.go
+++ b/db.go
@@ -130,9 +130,7 @@ func (db *DB) startSyncer(interval time.Duration) {
 			default:
 				modifications := db.metrics.Puts.Value() + db.metrics.Dels.Value()
 				if modifications != lastModifications {
-					db.mu.Lock()
 					db.Sync()
-					db.mu.Unlock()
 					lastModifications = modifications
 				}
 				time.Sleep(interval)
@@ -303,8 +301,10 @@ func (db *DB) Items() *ItemIterator {
 	return &ItemIterator{db: db}
 }
 
-// Sync commits the contents of the database to the backing FileSystem; this is a noop for an in-memory database. It must only be called while the database is opened.
+// Sync commits the contents of the database to the backing FileSystem; this is effectively a noop for an in-memory database. It must only be called while the database is opened.
 func (db *DB) Sync() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if err := db.data.Sync(); err != nil {
 		return err
 	}

--- a/db.go
+++ b/db.go
@@ -131,7 +131,7 @@ func (db *DB) startSyncer(interval time.Duration) {
 				modifications := db.metrics.Puts.Value() + db.metrics.Dels.Value()
 				if modifications != lastModifications {
 					db.mu.Lock()
-					db.sync()
+					db.Sync()
 					db.mu.Unlock()
 					lastModifications = modifications
 				}
@@ -303,7 +303,8 @@ func (db *DB) Items() *ItemIterator {
 	return &ItemIterator{db: db}
 }
 
-func (db *DB) sync() error {
+// Sync commits the contents of the database to the backing FileSystem; this is a noop for an in-memory database. It must only be called while the database is opened.
+func (db *DB) Sync() error {
 	if err := db.data.Sync(); err != nil {
 		return err
 	}


### PR DESCRIPTION
**Use case**

When using multiple databases at once, enabling the background sync feature in all of them would be redundant for most filesystems.

The current workaround, deciding which of them to enable background sync on, can get needlessly complicated.

**Alternatives**

- add a helper for the multi-db use case