### PR TITLE
Fix data corruption (issue #20)

### DIFF
--- a/db.go
+++ b/db.go
@@ -141,6 +141,12 @@ func bucketOffset(idx uint32) int64 {
 	return int64(headerSize) + (int64(bucketSize) * int64(idx))
 }
 
+func cloneBytes(src []byte) []byte {
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
 func (db *DB) startSyncer(interval time.Duration) {
 	ctx, cancel := context.WithCancel(context.Background())
 	db.cancelSyncer = cancel
@@ -277,7 +283,7 @@ func (db *DB) Get(key []byte) ([]byte, error) {
 					return true, err
 				}
 				if bytes.Equal(key, slKey) {
-					retValue = value
+					retValue = cloneBytes(value)
 					return true, nil
 				}
 				db.metrics.HashCollisions.Add(1)

--- a/db_test.go
+++ b/db_test.go
@@ -179,6 +179,31 @@ func TestEmptyValue(t *testing.T) {
 	}
 }
 
+func TestDataRecycle(t *testing.T) {
+	db, err := removeAndOpen("test.db", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Put([]byte{1}, []byte{8}); err != nil {
+		t.Fatal(err)
+	}
+	v, err := db.Get([]byte{1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDeepEqual(t, []byte{8}, v)
+	if err := db.Delete([]byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Put([]byte{1}, []byte{9}); err != nil {
+		t.Fatal(err)
+	}
+	assertDeepEqual(t, []byte{8}, v)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestClose(t *testing.T) {
 	db, err := removeAndOpen("test.db", nil)
 	if err != nil {

--- a/iterator.go
+++ b/iterator.go
@@ -41,6 +41,8 @@ func (it *ItemIterator) Next() ([]byte, []byte, error) {
 					if err != nil {
 						return true, err
 					}
+					key = cloneBytes(key)
+					value = cloneBytes(value)
 					it.queue = append(it.queue, item{key: key, value: value})
 				}
 				return false, nil


### PR DESCRIPTION
Fixes a race condition that could lead to data corruption. See https://github.com/akrylysov/pogreb/issues/20 for more details.

Adding an extra heap allocation and a copy made the read performance worse. I'll consider adding a new option `ReadOnly` which eliminates the copy for read-only use cases.

@holiman