### PR TITLE
Segment sequence ID

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -87,7 +87,7 @@ func (db *DB) compact(f *segment) (CompactionResult, error) {
 }
 
 func (db *DB) pickForCompaction() ([]*segment, error) {
-	segments, err := db.datalog.segmentsByModification()
+	segments, err := db.datalog.segmentsBySequenceID()
 	if err != nil {
 		return nil, err
 	}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -72,8 +72,8 @@ func TestCompaction(t *testing.T) {
 		assert.Nil(t, db.datalog.segments[0])
 		assert.Equal(t, &segmentMeta{PutRecords: 1}, db.datalog.segments[1].meta)
 		// Compacted file was removed.
-		assert.Equal(t, false, fileExists(filepath.Join(db.opts.path, segmentName(0))))
-		assert.Equal(t, false, fileExists(filepath.Join(db.opts.path, segmentMetaName(0))))
+		assert.Equal(t, false, fileExists(filepath.Join(db.opts.path, segmentName(0, 1))))
+		assert.Equal(t, false, fileExists(filepath.Join(db.opts.path, segmentMetaName(0, 1))))
 	})
 
 	run("compact entire segment", func(t *testing.T, db *DB) {

--- a/datalog_test.go
+++ b/datalog_test.go
@@ -15,7 +15,7 @@ func TestDatalog(t *testing.T) {
 	assert.Equal(t, &segmentMeta{PutRecords: 1}, db.datalog.segments[0].meta)
 	assert.Nil(t, db.datalog.segments[1])
 
-	sm, err := db.datalog.segmentsByModification()
+	sm, err := db.datalog.segmentsBySequenceID()
 	assert.Nil(t, err)
 	assert.Equal(t, []*segment{db.datalog.segments[0]}, sm)
 
@@ -26,7 +26,7 @@ func TestDatalog(t *testing.T) {
 	assert.Equal(t, &segmentMeta{PutRecords: 1, Full: true}, db.datalog.segments[0].meta)
 	assert.Equal(t, &segmentMeta{PutRecords: 1}, db.datalog.segments[1].meta)
 
-	sm, err = db.datalog.segmentsByModification()
+	sm, err = db.datalog.segmentsBySequenceID()
 	assert.Nil(t, err)
 	assert.Equal(t, []*segment{db.datalog.segments[0], db.datalog.segments[1]}, sm)
 

--- a/db_test.go
+++ b/db_test.go
@@ -139,7 +139,7 @@ func TestSimple(t *testing.T) {
 
 	// Simulate crash.
 	assert.Nil(t, touchFile(filepath.Join("test.db", lockName)))
-	assert.Nil(t, os.Remove(filepath.Join("test.db", segmentMetaName(0))))
+	assert.Nil(t, os.Remove(filepath.Join("test.db", segmentMetaName(0, 1))))
 	assert.Nil(t, os.Remove(filepath.Join("test.db", indexMetaName)))
 
 	// Open and check again

--- a/recovery.go
+++ b/recovery.go
@@ -68,7 +68,7 @@ type recoveryIterator struct {
 }
 
 func newRecoveryIterator(dl *datalog) (*recoveryIterator, error) {
-	files, err := dl.segmentsByModification()
+	files, err := dl.segmentsBySequenceID()
 	if err != nil {
 		return nil, err
 	}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRecovery(t *testing.T) {
-	dfPath := filepath.Join("test.db", segmentName(0))
+	segPath := filepath.Join("test.db", segmentName(0, 1))
 	testCases := []struct {
 		name string
 		fn   func() error
@@ -17,52 +17,52 @@ func TestRecovery(t *testing.T) {
 		{
 			name: "all zeroes",
 			fn: func() error {
-				return appendFile(dfPath, make([]byte, 128))
+				return appendFile(segPath, make([]byte, 128))
 			},
 		},
 		{
 			name: "partial kv size",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1})
+				return appendFile(segPath, []byte{1})
 			},
 		},
 		{
 			name: "only kv size",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0})
 			},
 		},
 		{
 			name: "kv size and key",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1})
 			},
 		},
 		{
 			name: "kv size, key, value",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1, 1})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1, 1})
 			},
 		},
 		{
 			name: "kv size, key, value, partial crc32",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40})
 			},
 		},
 		{
 			name: "kv size, key, value, invalid crc32",
 			fn: func() error {
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40, 19, 197, 0})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40, 19, 197, 0})
 			},
 		},
 		{
 			name: "corrupted and not corrupted record",
 			fn: func() error {
-				if err := appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40, 19, 197, 0}); err != nil {
+				if err := appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 40, 19, 197, 0}); err != nil {
 					return err
 				}
-				return appendFile(dfPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 133, 13, 200, 12})
+				return appendFile(segPath, []byte{1, 0, 1, 0, 0, 0, 1, 1, 133, 13, 200, 12})
 			},
 		},
 	}
@@ -71,7 +71,7 @@ func TestRecovery(t *testing.T) {
 		t.Run(fmt.Sprintf("case %s", testCase.name), func(t *testing.T) {
 			db, err := createTestDB(nil)
 			assert.Nil(t, err)
-			// Fill file 0.
+			// Fill segment 0.
 			var i uint8
 			for i = 0; i < 128; i++ {
 				assert.Nil(t, db.Put([]byte{i}, []byte{i}))

--- a/segment.go
+++ b/segment.go
@@ -21,13 +21,14 @@ const (
 // It consists of a sequence of binary-encoded variable length records.
 type segment struct {
 	*file
-	id      uint16
-	meta    *segmentMeta
-	modTime int64
+	id         uint16 // Physical segment identifier.
+	sequenceID uint64 // Logical monotonically increasing segment identifier.
+	name       string
+	meta       *segmentMeta
 }
 
-func segmentName(id uint16) string {
-	return fmt.Sprintf("%05d%s", id, segmentExt)
+func segmentName(id uint16, sequenceID uint64) string {
+	return fmt.Sprintf("%05d-%d%s", id, sequenceID, segmentExt)
 }
 
 type segmentMeta struct {
@@ -38,8 +39,8 @@ type segmentMeta struct {
 	DeletedBytes  uint32
 }
 
-func segmentMetaName(id uint16) string {
-	return fmt.Sprintf("%05d%s%s", id, segmentExt, metaExt)
+func segmentMetaName(id uint16, sequenceID uint64) string {
+	return segmentName(id, sequenceID) + metaExt
 }
 
 // Binary representation of a segment record:


### PR DESCRIPTION
Recovery and compaction need to know the logical order of segments (the order in which segments were created and updated).

`datalog` relied on file modification time to determine segment order. Relying on the modification time is fragile: 
- The actual modification time may get lost when transferring files over network or copying them. 
- It's not impossible to create two files with same modification time.

This PR introduces _segment sequence ID_ - monotonically increasing identifier used for ordering. 