### PR TITLE
add ReadOnly config option for read-only filesystems

### DIFF
--- a/datalog.go
+++ b/datalog.go
@@ -79,7 +79,7 @@ func parseSegmentName(name string) (uint16, uint64, error) {
 }
 
 func (dl *datalog) openSegment(name string, id uint16, seqID uint64) (*segment, error) {
-	f, err := openFile(dl.opts.FileSystem, name, false)
+	f, err := openFile(dl.opts.FileSystem, name, false, dl.opts.ReadOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (dl *datalog) openSegment(name string, id uint16, seqID uint64) (*segment, 
 	meta := &segmentMeta{}
 	if !f.empty() {
 		metaName := name + metaExt
-		if err := readGobFile(dl.opts.FileSystem, metaName, &meta); err != nil {
+		if err := readGobFile(dl.opts.FileSystem, metaName, &meta, dl.opts.ReadOnly); err != nil {
 			logger.Printf("error reading segment meta %d: %v", id, err)
 			// TODO: rebuild meta?
 		}
@@ -235,7 +235,7 @@ func (dl *datalog) close() error {
 			return err
 		}
 		metaName := seg.name + metaExt
-		if err := writeGobFile(dl.opts.FileSystem, metaName, seg.meta); err != nil {
+		if err := writeGobFile(dl.opts.FileSystem, metaName, seg.meta, dl.opts.ReadOnly); err != nil {
 			return err
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -14,10 +14,13 @@ type file struct {
 	size int64
 }
 
-func openFile(fsyst fs.FileSystem, name string, truncate bool) (*file, error) {
-	flag := os.O_CREATE | os.O_RDWR
-	if truncate {
-		flag |= os.O_TRUNC
+func openFile(fsyst fs.FileSystem, name string, truncate bool, readOnly bool) (*file, error) {
+	var flag int = os.O_RDONLY
+	if !readOnly {
+		flag = os.O_CREATE | os.O_RDWR
+		if truncate {
+			flag |= os.O_TRUNC
+		}
 	}
 	fi, err := fsyst.OpenFile(name, flag, os.FileMode(0640))
 	f := &file{}

--- a/gobfile.go
+++ b/gobfile.go
@@ -6,8 +6,8 @@ import (
 	"github.com/akrylysov/pogreb/fs"
 )
 
-func readGobFile(fsys fs.FileSystem, name string, v interface{}) error {
-	f, err := openFile(fsys, name, false)
+func readGobFile(fsys fs.FileSystem, name string, v interface{}, readOnly bool) error {
+	f, err := openFile(fsys, name, false, readOnly)
 	if err != nil {
 		return err
 	}
@@ -16,8 +16,8 @@ func readGobFile(fsys fs.FileSystem, name string, v interface{}) error {
 	return dec.Decode(v)
 }
 
-func writeGobFile(fsys fs.FileSystem, name string, v interface{}) error {
-	f, err := openFile(fsys, name, true)
+func writeGobFile(fsys fs.FileSystem, name string, v interface{}, readOnly bool) error {
+	f, err := openFile(fsys, name, true, readOnly)
 	if err != nil {
 		return err
 	}

--- a/index.go
+++ b/index.go
@@ -38,11 +38,11 @@ type indexMeta struct {
 type matchKeyFunc func(slot) (bool, error)
 
 func openIndex(opts *Options) (*index, error) {
-	main, err := openFile(opts.FileSystem, indexMainName, false)
+	main, err := openFile(opts.FileSystem, indexMainName, false, opts.ReadOnly)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening main index")
 	}
-	overflow, err := openFile(opts.FileSystem, indexOverflowName, false)
+	overflow, err := openFile(opts.FileSystem, indexOverflowName, false, opts.ReadOnly)
 	if err != nil {
 		_ = main.Close()
 		return nil, errors.Wrap(err, "opening overflow index")
@@ -76,12 +76,12 @@ func (idx *index) writeMeta() error {
 		SplitBucketIndex:    idx.splitBucketIdx,
 		FreeOverflowBuckets: idx.freeBucketOffs,
 	}
-	return writeGobFile(idx.opts.FileSystem, indexMetaName, m)
+	return writeGobFile(idx.opts.FileSystem, indexMetaName, m, idx.opts.ReadOnly)
 }
 
 func (idx *index) readMeta() error {
 	m := indexMeta{}
-	if err := readGobFile(idx.opts.FileSystem, indexMetaName, &m); err != nil {
+	if err := readGobFile(idx.opts.FileSystem, indexMetaName, &m, idx.opts.ReadOnly); err != nil {
 		return err
 	}
 	idx.level = m.Level

--- a/options.go
+++ b/options.go
@@ -25,6 +25,9 @@ type Options struct {
 	// Default: fs.OSMMap.
 	FileSystem fs.FileSystem
 
+	// Does DB reside on read-only filesystem?
+	ReadOnly bool
+
 	maxSegmentSize             uint32
 	compactionMinSegmentSize   uint32
 	compactionMinFragmentation float32


### PR DESCRIPTION
This PR adds a ReadOnly config option to be able to put the database on a read-only filesystem.
Enabling this config options disables the Lockfile mechanism and sets all file access flags to `O_RDONLY`.
