### PR TITLE
Generics

### DIFF
--- a/datalog_test.go
+++ b/datalog_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/akrylysov/pogreb/internal/assert"
 )
 
-func (dl *datalog) segmentMetas() []segmentMeta {
+func (dl *datalog[K, V]) segmentMetas() []segmentMeta {
 	var metas []segmentMeta
 	for _, seg := range dl.segmentsBySequenceID() {
 		metas = append(metas, *seg.meta)

--- a/db_test.go
+++ b/db_test.go
@@ -87,7 +87,7 @@ func TestHeaderSize(t *testing.T) {
 	}
 }
 
-func createTestDB(opts *Options) (*DB, error) {
+func createTestDB(opts *Options) (*DB[[]byte, []byte], error) {
 	if opts == nil {
 		opts = &Options{FileSystem: testFS}
 	} else {
@@ -103,7 +103,7 @@ func createTestDB(opts *Options) (*DB, error) {
 	for _, file := range files {
 		_ = testFS.Remove(filepath.Join(path, file.Name()))
 	}
-	return Open(path, opts)
+	return Open[[]byte, []byte](path, opts)
 }
 
 func TestEmpty(t *testing.T) {
@@ -111,7 +111,7 @@ func TestEmpty(t *testing.T) {
 	db, err := createTestDB(opts)
 	assert.Nil(t, err)
 	assert.Nil(t, db.Close())
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 	assert.Nil(t, db.Close())
 }
@@ -178,7 +178,7 @@ func TestFull(t *testing.T) {
 	verifyKeysAndClose(0)
 
 	// Open and check again
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 	verifyKeysAndClose(0)
 
@@ -188,14 +188,14 @@ func TestFull(t *testing.T) {
 	assert.Nil(t, testFS.Remove(filepath.Join(testDBName, indexMetaName)))
 
 	// Open and check again
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 	verifyKeysAndClose(0)
 
 	assert.Equal(t, expectedSegMetas, db.datalog.segmentMetas())
 
 	// Update all items
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 	for i = 0; i < n; i++ {
 		assert.Nil(t, db.Put([]byte{i}, []byte{i + 6}))
@@ -203,7 +203,7 @@ func TestFull(t *testing.T) {
 	verifyKeysAndClose(6)
 
 	// Delete all items
-	db, err = Open(testDBName, &Options{BackgroundSyncInterval: time.Millisecond})
+	db, err = Open[[]byte, []byte](testDBName, &Options{BackgroundSyncInterval: time.Millisecond})
 	assert.Nil(t, err)
 	for i = 0; i < n; i++ {
 		assert.Nil(t, db.Delete([]byte{i}))
@@ -223,7 +223,7 @@ func TestLock(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Opening already opened database returns an error.
-	db2, err2 := Open(testDBName, opts)
+	db2, err2 := Open[string, string](testDBName, opts)
 	assert.Nil(t, db2)
 	assert.NotNil(t, err2)
 
@@ -304,7 +304,7 @@ func TestCorruptedIndex(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, f.Close())
 
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, db)
 	assert.NotNil(t, err)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Example() {
-	db, err := pogreb.Open("pogreb.test", nil)
+	db, err := pogreb.Open[string, string]("pogreb.test", nil)
 	if err != nil {
 		log.Fatal(err)
 		return
@@ -15,12 +15,12 @@ func Example() {
 	defer db.Close()
 
 	// Insert a new key-value pair.
-	if err := db.Put([]byte("testKey"), []byte("testValue")); err != nil {
+	if err := db.Put("testKey", "testValue"); err != nil {
 		log.Fatal(err)
 	}
 
 	// Retrieve the inserted value.
-	val, err := db.Get([]byte("testKey"))
+	val, err := db.Get("testKey")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/akrylysov/pogreb
 
-go 1.12
+go 1.18

--- a/internal/hash/murmurhash32.go
+++ b/internal/hash/murmurhash32.go
@@ -10,7 +10,7 @@ const (
 )
 
 // Sum32WithSeed is a port of MurmurHash3_x86_32 function.
-func Sum32WithSeed(data []byte, seed uint32) uint32 {
+func Sum32WithSeed[String []byte | string](data String, seed uint32) uint32 {
 	h1 := seed
 	dlen := len(data)
 

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -84,12 +84,12 @@ func TestRecovery(t *testing.T) {
 
 			assert.Nil(t, testCase.fn())
 
-			db, err = Open(testDBName, opts)
+			db, err = Open[[]byte, []byte](testDBName, opts)
 			assert.Nil(t, err)
 			assert.Equal(t, uint32(128), db.Count())
 			assert.Nil(t, db.Close())
 
-			db, err = Open(testDBName, opts)
+			db, err = Open[[]byte, []byte](testDBName, opts)
 			assert.Nil(t, err)
 			assert.Equal(t, uint32(128), db.Count())
 			for i = 0; i < 128; i++ {
@@ -115,7 +115,7 @@ func TestRecoveryDelete(t *testing.T) {
 	// Simulate crash.
 	assert.Nil(t, touchFile(testFS, filepath.Join(testDBName, lockName)))
 
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 
 	assert.Equal(t, uint32(1), db.Count())
@@ -180,7 +180,7 @@ func TestRecoveryCompaction(t *testing.T) {
 	// Simulate crash.
 	assert.Nil(t, touchFile(testFS, filepath.Join(testDBName, lockName)))
 
-	db, err = Open(testDBName, opts)
+	db, err = Open[[]byte, []byte](testDBName, opts)
 	assert.Nil(t, err)
 
 	assert.Equal(t, uint32(2), db.Count())

--- a/segment.go
+++ b/segment.go
@@ -61,7 +61,7 @@ func encodedRecordSize(kvSize uint32) uint32 {
 	return 2 + 4 + kvSize + 4
 }
 
-func encodeRecord(key []byte, value []byte, rt recordType) []byte {
+func encodeRecord[K, V String](key K, value V, rt recordType) []byte {
 	size := encodedRecordSize(uint32(len(key) + len(value)))
 	data := make([]byte, size)
 	binary.LittleEndian.PutUint16(data[:2], uint16(len(key)))
@@ -79,12 +79,12 @@ func encodeRecord(key []byte, value []byte, rt recordType) []byte {
 	return data
 }
 
-func encodePutRecord(key []byte, value []byte) []byte {
+func encodePutRecord[K, V String](key K, value V) []byte {
 	return encodeRecord(key, value, recordTypePut)
 }
 
-func encodeDeleteRecord(key []byte) []byte {
-	return encodeRecord(key, nil, recordTypeDelete)
+func encodeDeleteRecord[K String](key K) []byte {
+	return encodeRecord(key, []byte(nil), recordTypeDelete)
 }
 
 // segmentIterator iterates over segment records.


### PR DESCRIPTION
Go's generics are pretty good. The bytes.Equal omission like `string(key) == string(other)` does not allocate memory. For generic returns I have replaced bytesClone with typedCopy in db.go.